### PR TITLE
Remove the inreplace instruction for sysconfig in the Python 3.12 formula

### DIFF
--- a/Formula/python@3.12.6.rb
+++ b/Formula/python@3.12.6.rb
@@ -160,9 +160,6 @@ class PythonAT3126 < Formula
         args << "--with-dbmliborder=bdb"
       end
   
-      # Resolve HOMEBREW_PREFIX in our sysconfig modification.
-      inreplace "Lib/sysconfig.py", "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX
-  
       if OS.linux?
         # Python's configure adds the system ncurses include entry to CPPFLAGS
         # when doing curses header check. The check may fail when there exists


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Remove the inreplace instruction for sysconfig in the Python 3.12 formula

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The build currently fail with 

```
Lib/sysconfig.py:
  expected replacement of "@@HOMEBREW_PREFIX@@" with "/usr/local"
```

Relates to https://github.com/Homebrew/homebrew-core/pull/196341/files

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
