### PR TITLE
Disable warnings for int-conversion on pkg-build

### DIFF
--- a/Formula/pkg-config@0.29.2.rb
+++ b/Formula/pkg-config@0.29.2.rb
@@ -26,6 +26,8 @@ class PkgConfigAT0292 < Formula
       #{HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/#{MacOS.version}
     ].uniq.join(File::PATH_SEPARATOR)
 
+    ENV.append_to_cflags "-Wno-int-conversion"
+
     system "./configure", "--disable-debug",
                           "--prefix=#{prefix}",
                           "--disable-host-tool",


### PR DESCRIPTION

### What does this PR do?

This disables integer conversion-related warnings that result in errors while building pkg-build.

### Motivation

[ABLD-293](https://datadoghq.atlassian.net/browse/ABLD-293)

While trying to upgrade our CI runners from ventura to sonoma (https://github.com/DataDog/ci-platform-machine-images/pull/503), which also comes with an upgrade of the XCode toolchain, we hit errors ([example](https://gitlab.ddbuild.io/DataDog/ci-platform-machine-images/-/jobs/1221789215#L1267)) related to integer to pointer conversions, such as:

```
gatomic.c:464:10: error: incompatible integer to pointer conversion passing 'gsize' (aka 'unsigned long') to parameter of type 'gpointer' (aka 'void *') [-Wint-conversion]
```

This is likely coming from some default changing on the toolchain, therefore adding the `-Wno-int-conversion` flag fixes the build (as seen in this [job](https://gitlab.ddbuild.io/DataDog/ci-platform-machine-images/-/jobs/1224899880) run off a [commit](https://github.com/DataDog/ci-platform-machine-images/pull/503/commits/ff6b8db0fcb5d5c2768df06b1ce284b2d6c59c10) that tests against this branch).

### Additional Notes

pkg-config is old and there are no newer releases. There's pkgconf as a possible replacement but fixing the build by adding a flag is lower friction than trying to migrate, and given that we're transitioning to Bazel and we'll soon not need to have pkg-config in the AMI, this sounds like the best way forward.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->


[ABLD-293]: https://datadoghq.atlassian.net/browse/ABLD-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ