### PR TITLE
Update gimme formula to 1.5.6

### DIFF
--- a/Formula/gimme@1.5.6.rb
+++ b/Formula/gimme@1.5.6.rb
@@ -1,8 +1,8 @@
 class GimmeAT154 < Formula
   desc "Shell script to install any Go version"
   homepage "https://github.com/travis-ci/gimme"
-  url "https://github.com/travis-ci/gimme/archive/v1.5.4.tar.gz"
-  sha256 "71036f892b3cae08f29be6fd4c69fb20d9b003ec80a24221d73e995e12ab0fe0"
+  url "https://github.com/travis-ci/gimme/archive/v1.5.6.tar.gz"
+  sha256 "50c42ec01505bee0e5b60165a0f577fe1e08fe9278fe3fe4b073c521f781c61e"
   license "MIT"
 
   def install


### PR DESCRIPTION
### Motivation

Improved support for new versions of Go, encountered in https://github.com/DataDog/datadog-agent/pull/43774

```
...
$ export GO_VERSION="$(cat .go-version)"
$ eval "$(gimme $GO_VERSION)"
Unable to setup go bootstrap from existing or binary
I don't have any idea what to do with '1.25.5'.
  (using download type 'auto')
```

### Additional Notes

The use of such an installer script is unnecessary and we will eventually remove this in favor of direct downloads.